### PR TITLE
show current file name in extra label instead of window title

### DIFF
--- a/frame_editor/src/frame_editor/FrameEditorGUI.ui
+++ b/frame_editor/src/frame_editor/FrameEditorGUI.ui
@@ -15,6 +15,13 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QLabel" name="lab_file_name">
+     <property name="text">
+      <string>New file - frame editor</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QToolBar" name="mainToolBar"/>
    </item>
    <item>
@@ -51,8 +58,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>321</width>
-              <height>548</height>
+              <width>312</width>
+              <height>562</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -82,7 +89,8 @@
                   <string>Duplicate</string>
                  </property>
                  <property name="icon">
-                  <iconset theme="edit-copy"/>
+                  <iconset theme="edit-copy">
+                   <normaloff>.</normaloff>.</iconset>
                  </property>
                 </widget>
                </item>
@@ -859,8 +867,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>137</width>
-             <height>590</height>
+             <width>159</width>
+             <height>586</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_6">

--- a/frame_editor/src/frame_editor/project_plugin.py
+++ b/frame_editor/src/frame_editor/project_plugin.py
@@ -195,7 +195,7 @@ class ProjectPlugin(Plugin):
             shown_name = file_name
             # recent files...
 
-        self.widget.setWindowTitle(self.tr('{} [*] - {}'.format(shown_name, "frame editor")))
+        self.widget.lab_file_name.setText(self.tr('{} [*] - {}'.format(shown_name, "frame editor")))
 
     def stripped_name(self, full_name):
         return QtCore.QFileInfo(full_name).fileName()

--- a/frame_editor/src/frame_editor/rqt_editor.py
+++ b/frame_editor/src/frame_editor/rqt_editor.py
@@ -74,6 +74,7 @@ class FrameEditorGUI(ProjectPlugin, Interface):
 
         #if context.serial_number() > 1:
         #    widget.setWindowTitle(widget.windowTitle() + (' (%d)' % context.serial_number()))
+        widget.setWindowTitle("frame editor")
 
 
         ## Undo View


### PR DESCRIPTION
Solves the bug that at startup the title is always an old file name
(probably cached by rqt).