### PR TITLE
Fix saving asterisk (*)

### DIFF
--- a/frame_editor/src/frame_editor/project_plugin.py
+++ b/frame_editor/src/frame_editor/project_plugin.py
@@ -128,6 +128,8 @@ class ProjectPlugin(Plugin):
                                                             QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No, QtWidgets.QMessageBox.Yes)
                     if choice == QtWidgets.QMessageBox.Yes:
                         self.load_file(file_name)
+                        # trigger asterisk (content actually changed)
+                        self.clean_changed(False)
                     else:
                         self.load_file("")
                         self.load_file(file_name)
@@ -197,26 +199,36 @@ class ProjectPlugin(Plugin):
     def write_file(self, file_name):
         raise NotImplementedError
 
-    def update_current_filename(self):
-        ## Set clean
-        self.editor.undo_stack.setClean()
-        self.widget.setWindowModified(False)
-
+    def get_shown_name(self):
         file_name = self.editor.get_file_name()
 
         ## Window title
         shown_name = "Untitled"
         if not file_name == "":
             shown_name = file_name
-            # recent files...
+        
+        return shown_name
 
-        self.widget.lab_file_name.setText(self.tr('{} [*] - {}'.format(shown_name, "frame editor")))
+    def update_current_filename(self):
+        ## Set clean
+        self.editor.undo_stack.setClean()
+        self.widget.setWindowModified(False)
+
+        ## Window title
+        shown_name = self.get_shown_name()
+
+        self.widget.lab_file_name.setText(self.tr('{} - {}'.format(shown_name, "frame editor")))
 
     def stripped_name(self, full_name):
         return QtCore.QFileInfo(full_name).fileName()
 
     def clean_changed(self, is_clean):
         self.widget.setWindowModified(not is_clean)
+
+        # set file name label
+        modified_identifier = "*" if self.widget.isWindowModified else ""
+        shown_name = self.get_shown_name()
+        self.widget.lab_file_name.setText(self.tr('{}{} - {}'.format(shown_name, modified_identifier, "frame editor")))
 
 
 

--- a/frame_editor/src/frame_editor/rqt_editor.py
+++ b/frame_editor/src/frame_editor/rqt_editor.py
@@ -139,11 +139,13 @@ class FrameEditorGUI(ProjectPlugin, Interface):
 
     @Slot(int)
     def update_all(self, level):
+        if level & 0:
+            self.update_current_filename()
+
         ## Update list widgets
         if level & 1:
             self.update_frame_list()
             self.update_tf_list()
-            self.update_current_filename()
 
         ## Update the currently selected frame
         if level & 2:


### PR DESCRIPTION
Fixes the asterisk indicating file changes.

known "issue": Selecting a frame is a change as well (cannot simply be changed due to undostack implementation), triggering the asterisk
